### PR TITLE
README: Fix typo in installation command, suggest -u flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Installation
 Install the temple command line tool with the following.
 
 ```bash
-go get github.com/go-humble/temple`
+go get -u github.com/go-humble/temple
 ```
 
 You may also need to install gopherjs. The latest version is recommended. Install
 gopherjs with:
 
-```
+```bash
 go get -u github.com/gopherjs/gopherjs
 ```
 


### PR DESCRIPTION
Previously, the command had an unneeded backtick (`) at the end.

Also add `-u` flag to get the latest version of `temple` and all of its dependencies. This should be more predictable and reliable in the general case.

Your CONTRIBUTING.md file says to make PRs against `develop` branch rather than `master`, yet surprisingly the `develop` branch is 7 commits behind `master` (rather than ahead or equal). Is your CONTRIBUTING.md file up to date?

I just want to make one commit 9979cdd5c079402896a4e6c31e802ea0068bb1aa to the `master` branch to fix a typo in the README, the rest are unrelated...
